### PR TITLE
fix 5 dataset, add resize(32) in test_transforms

### DIFF
--- a/config/icarl_5dataset.yaml
+++ b/config/icarl_5dataset.yaml
@@ -1,0 +1,71 @@
+includes:
+  - headers/data.yaml
+  - headers/device.yaml
+  # - headers/model.yaml
+  # - headers/optimizer.yaml
+  # - backbones/resnet12.yaml
+
+warmup: 0
+
+dataset: 5-datasets # [cifar100, binary_cifar100, ...]
+data_root: /data/cyy/processed_data2/5-dataset/
+class_order: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+              10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+              20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+              30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+              40, 41, 42, 43, 44, 45, 46, 47, 48, 49]
+testing_times: 1
+
+save_path: ./
+# data
+init_cls_num: 10
+inc_cls_num: 10
+task_num: 5
+
+
+batch_size: 128
+
+init_epoch: 1  #100
+epoch: 1  #100
+ 
+device_ids: 2
+n_gpu: 1
+val_per_epoch: 1
+
+
+optimizer:
+  name: SGD
+  kwargs:
+    lr: 0.1
+    momentum: 0.9
+    weight_decay: 0.0005
+
+lr_scheduler:
+  name: CosineAnnealingLR
+  kwargs:
+    T_max: 100
+
+
+backbone:
+  name: cifar_resnet32
+  kwargs:
+    num_classes: 100
+    args: 
+      dataset: cifar100
+
+
+buffer:
+  name: LinearHerdingBuffer
+  kwargs:
+    buffer_size: 2000
+    batch_size: 64
+    # strategy: herding     # random, equal_random, reservoir, herding
+
+classifier:
+  name: ICarl
+  kwargs:
+    num_class: 50
+    feat_dim: 64
+    init_cls_num: 10
+    inc_cls_num: 10
+    task_num: 5

--- a/core/data/data.py
+++ b/core/data/data.py
@@ -263,9 +263,78 @@ class TinyImageNetTransform:
         else:
             raise ValueError("Unsupported model type")
 
+
+class FiveDatasetsTransform:
+    MEAN = [0.5071, 0.4866,  0.4409]
+    STD = [0.2675, 0.2565, 0.2761]
+    
+    common_trfs = [transforms.ToTensor(),
+                   transforms.Normalize(mean=MEAN, std=STD)]
+    
+    resnet_train_transform = transforms.Compose([
+        transforms.RandomCrop(32, padding=4),
+        transforms.RandomHorizontalFlip(),
+        transforms.ColorJitter(brightness=63 / 255),
+        *common_trfs
+    ])
+    
+    resnet_test_transform = transforms.Compose([
+        transforms.Resize(32),
+        *common_trfs
+    ])
+
+    # from 
+    dset_mean = (0., 0., 0.)
+    dset_std = (1., 1., 1.)
+    vit_train_transform = transforms.Compose([
+        transforms.RandomResizedCrop(224),
+        transforms.RandomHorizontalFlip(),
+        transforms.ToTensor(),
+        transforms.Normalize(dset_mean, dset_std)])
+    
+    vit_test_transform = transforms.Compose([
+        transforms.Resize(224),
+        transforms.ToTensor(),
+        transforms.Normalize(dset_mean, dset_std)])
+
+    # from trust region gradient projection
+    mean=[x/255 for x in [125.3,123.0,113.9]]
+    std=[x/255 for x in [63.0,62.1,66.7]]
+
+    alexnet_train_transform = transforms.Compose([
+        transforms.Resize(32),
+        transforms.ToTensor(),
+        transforms.Normalize(mean,std)])
+
+    alexnet_test_transform = transforms.Compose([
+        transforms.Resize(32),
+        transforms.ToTensor(),
+        transforms.Normalize(mean,std)])
+
+    @staticmethod
+    def get_transform(model_type, mode):
+        if model_type == 'resnet':
+            if mode == 'train':
+                return FiveDatasetsTransform.resnet_train_transform
+            elif mode == 'test':
+                return FiveDatasetsTransform.resnet_test_transform
+        elif model_type == 'vit':
+            if mode == 'train':
+                return FiveDatasetsTransform.vit_train_transform
+            elif mode == 'test':
+                return FiveDatasetsTransform.vit_test_transform
+        elif model_type == 'alexnet':
+            if mode == 'train':
+                return FiveDatasetsTransform.alexnet_train_transform
+            elif mode == 'test':
+                return FiveDatasetsTransform.alexnet_test_transform
+        else:
+            raise ValueError("Unsupported model type")
+
 transform_classes = {
     'cifar': CIFARTransform,
     'imagenet': ImageNetTransform,
     'imagenet-r': ImageNetRTransform,
-    'tiny-imagenet': TinyImageNetTransform
+    'tiny-imagenet': TinyImageNetTransform,
+    '5-datasets': FiveDatasetsTransform
 }


### PR DESCRIPTION
- add `icarl_5dataset.yaml` demo config to run 5datsets
- add a specific transfrom to this dataset, when tesing, the image is resized to (32, 32) when using resnet.